### PR TITLE
Fix export lfs for OpenXRay

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lfs"]
 	path = lfs
-	url = https://github.com/lunarmodules/luafilesystem.git
+	url = https://github.com/OpenXRay/luafilesystem.git
 [submodule "lua-marshal"]
 	path = lua-marshal
 	url = https://github.com/OpenXRay/lua-marshal.git


### PR DESCRIPTION
This changes fix "module 'lfs' not found" when try to use lfs from lua scripts.